### PR TITLE
Improve exception handling for tolerance check.

### DIFF
--- a/netcompare/exceptions.py
+++ b/netcompare/exceptions.py
@@ -1,0 +1,5 @@
+"""Custom exceptions."""
+
+
+class InvalidDataFormat(BaseException):
+    """Exception for not expected data format."""


### PR DESCRIPTION
This PR is for issue #18 

Sample of data formats not currently supported and raised as exception. 
```
    raise InvalidDataFormat(
netcompare.exceptions.InvalidDataFormat: Tolerance check expects a certain diff data structure.
                {'key': {'sub_key': {'new_value': int, 'old_value': int}, ... }
                You have:
                {'power_level': {'new_value': 4, 'old_value': -4}}
```

```
    raise InvalidDataFormat(
netcompare.exceptions.InvalidDataFormat: Tolerance check expects a certain diff data structure.
                {'key': {'sub_key': {'new_value': int, 'old_value': int}, ... }
                You have:
                {'interfaces': {'Ethernet1': {'power_level': {'new_value': 4, 'old_value': -4}}, 'Ethernet3': {'power_level': {'new_value': 3, 'old_value': -3}}}}
```