### PR TITLE
[WIP] handle duplicated keys when fixing keys.

### DIFF
--- a/netcompare/utils/diff_helpers.py
+++ b/netcompare/utils/diff_helpers.py
@@ -77,5 +77,7 @@ def dict_merger(original_dict: Dict, dict_to_merge: Dict):
     for key in dict_to_merge.keys():
         if key in original_dict and isinstance(original_dict[key], dict) and isinstance(dict_to_merge[key], dict):
             dict_merger(original_dict[key], dict_to_merge[key])
+        elif key in original_dict.keys():
+            original_dict[key + "_dup!"] = dict_to_merge[key]  # avoid overwriting existing keys.
         else:
             original_dict[key] = dict_to_merge[key]

--- a/tests/test_diff_generator.py
+++ b/tests/test_diff_generator.py
@@ -131,7 +131,14 @@ exact_match_multi_nested_list = (
     },
 )
 
-textfsm_ospf_int_br_exact_match = (
+exact_match_textfsm_ospf_int_br_raw = (
+    "textfsm_ospf_int_br",
+    "",
+    [],
+    {"state": {"new_value": "DOWN", "old_value": "P2P", "new_value_dup!": "DR", "old_value_dup!": "BDR"}},
+)
+
+exact_match_textfsm_ospf_int_br_normalized = (
     "textfsm_ospf_int_br",
     "[*].[$interface$,area,ip_address_mask,cost,state,neighbors_fc]",
     [],
@@ -152,7 +159,8 @@ eval_tests = [
     exact_match_additional_item,
     exact_match_changed_item,
     exact_match_multi_nested_list,
-    textfsm_ospf_int_br_exact_match,
+    exact_match_textfsm_ospf_int_br_raw,
+    exact_match_textfsm_ospf_int_br_normalized,
 ]
 
 


### PR DESCRIPTION
Merging lists and grouping keys may lead to some keys being overwritten.

Example is `exact_match_textfsm_ospf_int_br_raw` test in `tests/test_diff_generator.py `

This is to show the issue and it is initial proposal, further work and agreement is expected.

Run ospf tests in scope with: `pytest -vs -k ospf`