### PR TITLE
Base class CheckType implemented as abstract class

### DIFF
--- a/netcompare/check_types.py
+++ b/netcompare/check_types.py
@@ -1,6 +1,7 @@
 """CheckType Implementation."""
 import re
 from typing import Mapping, Tuple, List, Dict, Any, Union
+from abc import ABC, abstractmethod
 import jmespath
 
 
@@ -17,11 +18,11 @@ from .evaluators import diff_generator, parameter_evaluator, regex_evaluator
 # pylint: disable=arguments-differ
 
 
-class CheckType:
-    """Check Type Class."""
+class CheckType(ABC):
+    """Check Type Base Abstract Class."""
 
     @staticmethod
-    def init(check_type):
+    def init(check_type: str):
         """Factory pattern to get the appropriate CheckType implementation.
 
         Args:
@@ -68,7 +69,7 @@ class CheckType:
             return values
 
         for element in values:  # process elements to check is lists should be flatten
-            # TODO: Not sure how this is working becasyse from `jmespath.search` it's supposed to get a flat list
+            # TODO: Not sure how this is working because from `jmespath.search` it's supposed to get a flat list
             # of str or Decimals, not another list...
             for item in element:
                 if isinstance(item, dict):  # raise if there is a dict, path must be more specific to extract data
@@ -88,25 +89,26 @@ class CheckType:
 
         return values
 
-    def evaluate(self, value_to_compare: Any, **kwargs) -> Tuple[Dict, bool]:
+    @abstractmethod
+    def evaluate(self, *args, **kwargs) -> Tuple[Dict, bool]:
         """Return the result of the evaluation and a boolean True if it passes it or False otherwise.
 
         This method is the one that each CheckType has to implement.
 
         Args:
-            value_to_compare: Similar value as above to perform comparison.
+            *args: arguments specific to child class implementation
+            **kwargs: named arguments
 
         Returns:
             tuple: Dictionary representing check result, bool indicating if differences are found.
         """
         # This method should call before any other logic the validation of the arguments
         # self.validate(**kwargs)
-        raise NotImplementedError
 
     @staticmethod
-    def validate(**kwargs):
+    @abstractmethod
+    def validate(**kwargs) -> None:
         """Method to validate arguments that raises proper exceptions."""
-        raise NotImplementedError
 
 
 class ExactMatchType(CheckType):

--- a/tests/test_type_checks.py
+++ b/tests/test_type_checks.py
@@ -1,12 +1,49 @@
-"Check Type unit tests."
+"""Check Type unit tests."""
 import pytest
-from netcompare.check_types import CheckType, ExactMatchType, ToleranceType
+from netcompare.check_types import CheckType, ExactMatchType, ToleranceType, ParameterMatchType, RegexType
 from .utility import load_json_file, load_mocks, ASSERT_FAIL_MESSAGE
+
+
+def test_child_class_raises_exception():
+    """Tests that exception is raised for child class when abstract methods are not implemented."""
+
+    class CheckTypeChild(CheckType):
+        """Test Class."""
+
+    with pytest.raises(TypeError) as error:
+        CheckTypeChild()  # pylint: disable=E0110
+
+    assert (
+        "Can't instantiate abstract class CheckTypeChild"
+        " with abstract methods evaluate, validate" in error.value.__str__()
+    )
+
+
+def test_child_class_proper_implementation():
+    """Test properly implemented child class can be instantiated."""
+
+    class CheckTypeChild(CheckType):
+        """Test Class."""
+
+        @staticmethod
+        def validate(**kwargs):
+            return None
+
+        def evaluate(self, *args, **kwargs):
+            return {}, True
+
+    check = CheckTypeChild()
+    assert isinstance(check, CheckTypeChild) and check.validate() is None and check.evaluate() == ({}, True)
 
 
 @pytest.mark.parametrize(
     "check_type_str, expected_class",
-    [("exact_match", ExactMatchType), ("tolerance", ToleranceType)],
+    [
+        ("exact_match", ExactMatchType),
+        ("tolerance", ToleranceType),
+        ("parameter_match", ParameterMatchType),
+        ("regex", RegexType),
+    ],
 )
 def test_check_init(check_type_str, expected_class):
     """Validate that the returned class is the expected one."""


### PR DESCRIPTION
This is a proposal to implement `CheckType` as abstract class and make `validate()` & `evaluate()` abstract methods.
This ensures that every child CheckType must have `validate()` & `evaluate()` methods implemented.

Tests show that `TypeError` exception is raised when an object is instantiated for a child class without `validate()` & `evaluate()` methods implemented.