### PR TITLE
Fix typing

### DIFF
--- a/netcompare/check_types.py
+++ b/netcompare/check_types.py
@@ -321,7 +321,7 @@ class OperatorType(CheckType):
                 f"check option all-same must have value of type bool. You have: {params_value} of type {type(params_value)}"
             )
 
-    def evaluate(self, value_to_compare: Any, params: Any) -> Tuple[Mapping, bool]:
+    def evaluate(self, value_to_compare: Any, params: Any) -> Tuple[Dict, bool]:
         """Operator evaluator implementation."""
         self.validate(**params)
         # For name consistency.

--- a/netcompare/evaluators.py
+++ b/netcompare/evaluators.py
@@ -1,6 +1,6 @@
 """Evaluators."""
 import re
-from typing import Any, Mapping, Dict
+from typing import Any, Mapping, Dict, Tuple
 from deepdiff import DeepDiff
 from .utils.diff_helpers import get_diff_iterables_items, fix_deepdiff_key_names
 from .operator import Operator
@@ -104,7 +104,7 @@ def regex_evaluator(values: Mapping, regex_expression: str, mode: str) -> Dict:
     return result
 
 
-def operator_evaluator(referance_data: Mapping, value_to_compare: Mapping) -> Dict:
+def operator_evaluator(referance_data: Mapping, value_to_compare: Mapping) -> Tuple[Dict, bool]:
     """Operator evaluator call."""
     # referance_data
     # {'mode': 'all-same', 'operator_data': True}


### PR DESCRIPTION
Minor fix to typing.
Reason: All evaluate() methods should have the same typing.